### PR TITLE
fix(post): fix bug if the output is empty

### DIFF
--- a/post.js
+++ b/post.js
@@ -110,7 +110,7 @@ function raw(jsonstring, filter, flags) {
     throw e;
   }
 
-  return stdout;
+  return stdout ?? '';
 }
 
 // takes an object as input and tries to return objects.


### PR DESCRIPTION
If the output is empty, for example if a filter like `.results[] | {name: .name}` is applied to an object where `results` is an empty list, the `raw` method returns `undefined` and not an empty string. It's easier to reason about if it returns an empty string instead.